### PR TITLE
feat(profiles): add agent family inventory

### DIFF
--- a/src/agent-inventory.test.ts
+++ b/src/agent-inventory.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_FAMILY,
+  CONFIGURABLE_BUILTIN_AGENTS,
+  EXCLUDED_BUILTIN_AGENTS,
+  KNOWN_BUILTIN_AGENTS,
+  buildAgentInventory,
+  classifyAgentName,
+  type AgentFamily,
+} from "./agent-inventory";
+
+describe("agent inventory", () => {
+  it.each([
+    ["sdd-apply", AGENT_FAMILY.SDD, true],
+    ["sdd-orchestrator", AGENT_FAMILY.SDD, false],
+    ["gentle-orchestrator", AGENT_FAMILY.SDD, false],
+    ["jd-judge-a", AGENT_FAMILY.JUDGMENT_DAY, true],
+    ["review-risk", AGENT_FAMILY.REVIEW, true],
+  ] as const)("classifies managed agent %s", (name, family, fallbackEligible) => {
+    expect(classifyAgentName(name)).toEqual({
+      family,
+      configurable: true,
+      fallbackEligible,
+    });
+  });
+
+  it.each([
+    "sdd-apply-fallback",
+    "jd-judge-a-fallback",
+    "review-risk-fallback",
+  ])("classifies managed fallback %s", (name) => {
+    expect(classifyAgentName(name)).toEqual({
+      family: AGENT_FAMILY.FALLBACK,
+      configurable: true,
+      fallbackEligible: false,
+    });
+  });
+
+  it("defines the exact configurable and excluded built-in sets", () => {
+    expect(CONFIGURABLE_BUILTIN_AGENTS).toEqual([
+      "general",
+      "explore",
+      "compaction",
+      "summary",
+      "title",
+    ]);
+    expect(EXCLUDED_BUILTIN_AGENTS).toEqual(["plan", "build"]);
+    expect(KNOWN_BUILTIN_AGENTS).toHaveLength(7);
+
+    for (const name of CONFIGURABLE_BUILTIN_AGENTS) {
+      expect(classifyAgentName(name)).toEqual({
+        family: AGENT_FAMILY.BUILTIN,
+        configurable: true,
+        fallbackEligible: false,
+      });
+    }
+    for (const name of EXCLUDED_BUILTIN_AGENTS) {
+      expect(classifyAgentName(name)).toEqual({
+        family: AGENT_FAMILY.BUILTIN,
+        configurable: false,
+        fallbackEligible: false,
+      });
+    }
+  });
+
+  it("classifies an unknown loaded agent as configurable custom", () => {
+    expect(classifyAgentName("gentle-ai-windows-validator")).toEqual({
+      family: AGENT_FAMILY.CUSTOM,
+      configurable: true,
+      fallbackEligible: false,
+    });
+  });
+
+  it("unifies loaded and profile agents without adding absent known agents", () => {
+    const inventory = buildAgentInventory({
+      loadedAgentNames: [
+        "sdd-orchestrator",
+        "gentle-orchestrator",
+        "review-risk",
+        "general",
+        "plan",
+        "gentle-ai-windows-validator",
+      ],
+      profileAgentNames: ["gentle-orchestrator", "sdd-spec", "summary"],
+    });
+    const byName = Object.fromEntries(inventory.map((entry) => [entry.name, entry]));
+
+    expect(inventory).toHaveLength(7);
+    expect(byName["gentle-orchestrator"]).toMatchObject({
+      aliases: ["sdd-orchestrator", "gentle-orchestrator"],
+      loaded: true,
+      profilePresent: true,
+      family: AGENT_FAMILY.SDD,
+      configurable: true,
+      fallbackEligible: false,
+    });
+    expect(byName["review-risk"]).toMatchObject({ loaded: true, profilePresent: false, fallbackEligible: true });
+    expect(byName["sdd-spec"]).toMatchObject({ loaded: false, profilePresent: true, fallbackEligible: true });
+    expect(byName.summary).toMatchObject({ loaded: false, profilePresent: true, configurable: true });
+    expect(byName.plan).toMatchObject({ family: AGENT_FAMILY.BUILTIN, configurable: false });
+    expect(byName["gentle-ai-windows-validator"]).toMatchObject({
+      family: AGENT_FAMILY.CUSTOM,
+      loaded: true,
+      profilePresent: false,
+      configurable: true,
+    });
+    expect(Object.keys(byName)).not.toEqual(expect.arrayContaining(["explore", "compaction", "title", "build"]));
+  });
+
+  it("preserves the legacy orchestrator canonical name when it is the only alias", () => {
+    expect(buildAgentInventory({ loadedAgentNames: ["sdd-orchestrator"] })).toEqual([
+      expect.objectContaining({
+        name: "sdd-orchestrator",
+        aliases: ["sdd-orchestrator"],
+        loaded: true,
+        profilePresent: false,
+      }),
+    ]);
+  });
+
+  it("publishes every required family", () => {
+    const families: AgentFamily[] = Object.values(AGENT_FAMILY);
+    expect(families).toEqual(["sdd", "judgment-day", "review", "fallback", "builtin", "custom"]);
+  });
+});

--- a/src/agent-inventory.ts
+++ b/src/agent-inventory.ts
@@ -1,0 +1,114 @@
+import { getOrchestratorPolicy } from "./orchestrator";
+import {
+  isFallbackEligibleSddAgent,
+  isManagedSddAgent,
+  isSddFallbackAgent,
+} from "./utils";
+
+export const AGENT_FAMILY = {
+  SDD: "sdd",
+  JUDGMENT_DAY: "judgment-day",
+  REVIEW: "review",
+  FALLBACK: "fallback",
+  BUILTIN: "builtin",
+  CUSTOM: "custom",
+} as const;
+
+export type AgentFamily = typeof AGENT_FAMILY[keyof typeof AGENT_FAMILY];
+
+export const CONFIGURABLE_BUILTIN_AGENTS = [
+  "general",
+  "explore",
+  "compaction",
+  "summary",
+  "title",
+] as const;
+
+export const EXCLUDED_BUILTIN_AGENTS = ["plan", "build"] as const;
+
+export const KNOWN_BUILTIN_AGENTS = [
+  ...CONFIGURABLE_BUILTIN_AGENTS,
+  ...EXCLUDED_BUILTIN_AGENTS,
+] as const;
+
+const configurableBuiltins = new Set<string>(CONFIGURABLE_BUILTIN_AGENTS);
+const knownBuiltins = new Set<string>(KNOWN_BUILTIN_AGENTS);
+
+export type AgentClassification = {
+  family: AgentFamily;
+  configurable: boolean;
+  fallbackEligible: boolean;
+};
+
+export type AgentInventoryEntry = AgentClassification & {
+  name: string;
+  aliases: string[];
+  loaded: boolean;
+  profilePresent: boolean;
+};
+
+export type AgentInventoryInput = {
+  loadedAgentNames?: readonly string[];
+  profileAgentNames?: readonly string[];
+  defaultAgent?: string;
+};
+
+export function classifyAgentName(agentName: string): AgentClassification {
+  if (isSddFallbackAgent(agentName)) {
+    return { family: AGENT_FAMILY.FALLBACK, configurable: true, fallbackEligible: false };
+  }
+
+  if (isManagedSddAgent(agentName)) {
+    const family = agentName.startsWith("jd-")
+      ? AGENT_FAMILY.JUDGMENT_DAY
+      : agentName.startsWith("review-")
+        ? AGENT_FAMILY.REVIEW
+        : AGENT_FAMILY.SDD;
+    return { family, configurable: true, fallbackEligible: isFallbackEligibleSddAgent(agentName) };
+  }
+
+  if (knownBuiltins.has(agentName)) {
+    return {
+      family: AGENT_FAMILY.BUILTIN,
+      configurable: configurableBuiltins.has(agentName),
+      fallbackEligible: false,
+    };
+  }
+
+  return { family: AGENT_FAMILY.CUSTOM, configurable: true, fallbackEligible: false };
+}
+
+export function buildAgentInventory({
+  loadedAgentNames = [],
+  profileAgentNames = [],
+  defaultAgent,
+}: AgentInventoryInput): AgentInventoryEntry[] {
+  const loaded = new Set(loadedAgentNames.filter(Boolean));
+  const profilePresent = new Set(profileAgentNames.filter(Boolean));
+  const observedNames = Array.from(new Set([...loaded, ...profilePresent]));
+  const policy = getOrchestratorPolicy(observedNames, defaultAgent);
+  const inventory = new Map<string, AgentInventoryEntry>();
+
+  for (const observedName of observedNames) {
+    const isOrchestratorAlias = policy.aliasNames.some((alias) => alias === observedName);
+    const name = isOrchestratorAlias ? policy.canonicalName : observedName;
+    const current = inventory.get(name);
+
+    if (current) {
+      if (!current.aliases.includes(observedName)) current.aliases.push(observedName);
+      current.loaded ||= loaded.has(observedName);
+      current.profilePresent ||= profilePresent.has(observedName);
+      continue;
+    }
+
+    inventory.set(name, {
+      name,
+      aliases: [observedName],
+      loaded: loaded.has(observedName),
+      profilePresent: profilePresent.has(observedName),
+      ...classifyAgentName(name),
+    });
+  }
+
+  return Array.from(inventory.values());
+}


### PR DESCRIPTION
## Summary

- Add typed classification for SDD, Judgment Day, review, fallback, built-in, and custom agent families.
- Add a unified inventory that combines loaded and profile-present agents while deduplicating orchestrator aliases.
- Capture configurability, fallback eligibility, and source metadata with focused regression coverage.

## Linked Issue

Related to #45

## Scope Justification

This is the minimum reusable foundation for the family-aware profile work proposed in #45. It intentionally does not change profile persistence, activation, bulk assignment, or the TUI; those integrations can be reviewed separately after the inventory contract is accepted.

The 239-line diff includes 125 lines of tests covering the public classification and inventory behavior.

## Validation

- Tests run: `npm ci`
- Tests run: `npm test` — 12 files and 250 tests passed
- Tests run: `npm test -- src/agent-inventory.test.ts` — 1 file and 13 tests passed
- Build: `npm run build` — passed
- Typecheck: `npm run typecheck` — passed
- Manual verification: inspected the staged diff and verified alias deduplication, loaded/profile union, built-in exclusions, and absence of unrelated tracked changes. Runtime harness is N/A because this PR introduces pure classification and inventory utilities without a runtime entrypoint.

## Checklist

- [x] I linked an issue
- [x] I kept the change as small and focused as possible
- [x] I explained the scope if the diff is broader than usual
- [x] I included validation notes