### PR TITLE
fix(profiles): clear residual reasoning effort and fallback configs on profile activation

### DIFF
--- a/src/profile-reasoning.test.ts
+++ b/src/profile-reasoning.test.ts
@@ -228,10 +228,11 @@ describe("profile reasoning helpers", () => {
       expect(next.clearedAgents).toEqual([]);
     });
 
-    it("clears stale reasoning effort for scoped primary agents when profile configs are absent", () => {
+    it("clears stale reasoning effort for scoped primary agents and fallbacks when profile configs are absent", () => {
       const next = applyProfileReasoningEffort({
         agent: {
-          "sdd-init": { model: "openai/gpt-5", reasoningEffort: "high", options: { reasoningEffort: "high" } },
+          "sdd-init": { model: "openai/gpt-5", reasoningEffort: "high", reasoning_effort: "high", options: { reasoningEffort: "high", reasoning_effort: "high", thinking: { type: "enabled" } } },
+          "sdd-init-fallback": { model: "openai/gpt-5", reasoningEffort: "high", reasoning_effort: "high", options: { reasoningEffort: "high", reasoning_effort: "high" } },
           "sdd-apply": { model: "openai/gpt-5", reasoningEffort: "low", options: { reasoningEffort: "low" } },
           "sdd-plan": { model: "openai/gpt-5", reasoningEffort: "medium" },
         },
@@ -243,12 +244,17 @@ describe("profile reasoning helpers", () => {
       } as any, providers as any);
 
       expect(next.config.agent["sdd-init"].reasoningEffort).toBeUndefined();
+      expect(next.config.agent["sdd-init"].reasoning_effort).toBeUndefined();
       expect(next.config.agent["sdd-init"].options.reasoningEffort).toBeUndefined();
+      expect(next.config.agent["sdd-init"].options.reasoning_effort).toBeUndefined();
+      expect(next.config.agent["sdd-init"].options.thinking).toBeUndefined();
+      expect(next.config.agent["sdd-init-fallback"].reasoningEffort).toBeUndefined();
+      expect(next.config.agent["sdd-init-fallback"].reasoning_effort).toBeUndefined();
       expect(next.config.agent["sdd-apply"].reasoningEffort).toBeUndefined();
       expect(next.config.agent["sdd-apply"].options.reasoningEffort).toBeUndefined();
       expect(next.config.agent["sdd-plan"].reasoningEffort).toBe("medium");
       expect(next.appliedAgents).toEqual([]);
-      expect(next.clearedAgents.sort()).toEqual(["sdd-apply", "sdd-init"]);
+      expect(next.clearedAgents.sort()).toEqual(["sdd-apply", "sdd-init", "sdd-init-fallback"]);
       expect(next.warnings).toEqual([]);
     });
 

--- a/src/profile-reasoning.ts
+++ b/src/profile-reasoning.ts
@@ -114,8 +114,11 @@ export function updateProfileReasoningEffort(profile: ProfileData, agentName: st
 function clearAgentReasoningEffort(agentConfig: any) {
   if (!agentConfig || typeof agentConfig !== "object") return;
   delete agentConfig.reasoningEffort;
+  delete agentConfig.reasoning_effort;
   if (agentConfig.options && typeof agentConfig.options === "object") {
     delete agentConfig.options.reasoningEffort;
+    delete agentConfig.options.reasoning_effort;
+    delete agentConfig.options.thinking;
   }
 }
 
@@ -161,6 +164,11 @@ export function applyProfileReasoningEffort(currentConfig: any, profile: Profile
     if (nextConfig?.agent?.[agentName] && typeof nextConfig.agent[agentName] === "object") {
       clearAgentReasoningEffort(nextConfig.agent[agentName]);
       clearedAgents.push(agentName);
+    }
+    const fallbackName = `${agentName}-fallback`;
+    if (nextConfig?.agent?.[fallbackName] && typeof nextConfig.agent[fallbackName] === "object") {
+      clearAgentReasoningEffort(nextConfig.agent[fallbackName]);
+      clearedAgents.push(fallbackName);
     }
   }
 


### PR DESCRIPTION
## Summary

- Extended `clearAgentReasoningEffort` to remove all residual reasoning keys (`reasoningEffort`, `reasoning_effort`, `options.reasoningEffort`, `options.reasoning_effort`, and `options.thinking`).
- Included `*-fallback` agents in the reasoning cleanup loop during profile activation when no profile configs are specified.
- Added unit tests verifying that all reasoning variants and fallback configurations are properly purged.

## Linked Issue

- Fixes #47

## Scope Justification

- Minimal surgical fix isolated to `src/profile-reasoning.ts` and its unit tests.

## Validation

- Tests run: `npm test` (237/237 tests pass), `npm run typecheck`, and `npm run build` (`tsup` clean build).
- Manual verification: Verified against global configurations with mixed camelCase/snake_case reasoning effort properties.

## Checklist

- [x] I linked an issue
- [x] I kept the change as small and focused as possible
- [x] I explained the scope if the diff is broader than usual
- [x] I included validation notes